### PR TITLE
Fix Markdown italics for legislation in vulnerability disclosure policy

### DIFF
--- a/VulnerabilityDisclosurePolicy.md
+++ b/VulnerabilityDisclosurePolicy.md
@@ -32,5 +32,5 @@ When you choose to share your contact information with us, we commit to communic
 *   To the best of our ability, we will confirm the existence of the vulnerability to you and be as transparent as possible about what steps we are taking during the remediation process, including on issues or challenges that may delay resolution. 
 *   We will prioritize fixing the vulnerability by looking at the impact, severity and exploit complexity. Vulnerability reports might take some time to triage or address. You’re welcome to ask the status but please no more than once every 14 days. That way, our teams can focus on the remediation.
 *   We will do our best to maintain an open dialogue with you to discuss issues and will work with you to determine whether and how the flaw reported will be made public.
-*   We will treat your report in accordance with the _Access to Information Act _and the_ Privacy Act_. 
+*   We will treat your report in accordance with the _Access to Information Act_ and the _Privacy Act_.
 *   We will notify you when the reported vulnerability is remediated, and you may be invited to confirm that the solution covers the vulnerability adequately.


### PR DESCRIPTION
Because I am a major formatting nerd.