### PR TITLE
Update security.md with content from VDP

### DIFF
--- a/security.md
+++ b/security.md
@@ -1,0 +1,38 @@
+[Français](https://github.com/cds-snc/covid-alert-documentation/blob/main/PolitiqueDivulgationVulnerabilites.md)
+
+# Vulnerability Disclosure Process for the COVID Alert service
+
+_Canadian Digital Service & Office of the Chief Information Officer_\
+_Date: 2020-07-31_
+
+The Government of Canada is committed to protecting the security and integrity of the COVID Alert service and the information and data that it processes. COVID Alert has been built in the open to increase trust and confidence in the service, and to create more opportunities for others to help to improve the service.
+
+## Submitting a vulnerability you’ve found
+
+Information you submit under this process is only used to mitigate or remediate vulnerabilities. 
+
+**Do not post security issues to our public repositories.**
+
+If you believe you have found a security vulnerability, notify us as soon as possible after you discover it. Please submit your report to us **by email at [security@cds-snc.ca](mailto:security@cds-snc.ca)**. You can submit reports anonymously. We do not support PGP-encrypted emails at this time. 
+
+### What we would like to see from you
+
+In your report:
+
+*   Write in English or French.
+*   Describe the vulnerability, where it was discovered, and the potential impact of exploitation. 
+*   Offer a detailed description of the steps to reproduce the vulnerability (proof of concept scripts or screenshots are helpful). These should be benign, non-destructive, proofs of concept so we can triage your report quickly and accurately. 
+*   Do not submit reports detailing non-exploitable vulnerabilities, or reports indicating that the services do not fully align with “best practice”, for example missing security headers, or a high volume of low-quality reports (for example, from an automated scanner).
+*   Do not communicate any vulnerabilities or associated details other than by means described in the published security.md file.
+*   Do not expect or demand financial compensation for your research and testing to disclose vulnerabilities.
+
+## What to expect 
+
+When you choose to share your contact information with us, we commit to communicating with you as openly and as quickly as possible.
+
+*   Within 3 business days, we will acknowledge that your report has been received. 
+*   To the best of our ability, we will confirm the existence of the vulnerability to you and be as transparent as possible about what steps we are taking during the remediation process, including on issues or challenges that may delay resolution. 
+*   We will prioritize fixing the vulnerability by looking at the impact, severity and exploit complexity. Vulnerability reports might take some time to triage or address. You’re welcome to ask the status but please no more than once every 14 days. That way, our teams can focus on the remediation.
+*   We will do our best to maintain an open dialogue with you to discuss issues and will work with you to determine whether and how the flaw reported will be made public.
+*   We will treat your report in accordance with the _Access to Information Act_ and the _Privacy Act_.
+*   We will notify you when the reported vulnerability is remediated, and you may be invited to confirm that the solution covers the vulnerability adequately.


### PR DESCRIPTION
I'm duplicating this rather than renaming the vdp file in the odd chance we have any upstream links pointing to it. This will make the GitHub integrations with security.MD file work better, rather than falling back onto our default .github/security.md files.

If there's a better way to link them, happy to roll this back.

